### PR TITLE
Do not escape whitespaces in file names

### DIFF
--- a/__test__/unix/print.test.js
+++ b/__test__/unix/print.test.js
@@ -53,12 +53,3 @@ test("sends PDF file to the specific printer", () => {
     expect(execAsync).toHaveBeenCalledWith(`lp`, [filename, "-d", printer]);
   });
 });
-
-test("escapes whitespaces in the file name", () => {
-  const filename = "my assets/pdf-sample.pdf";
-  return print(filename).then(() => {
-    expect(execAsync).toHaveBeenCalledWith("lp", [
-      "my\\ assets/pdf-sample.pdf"
-    ]);
-  });
-});

--- a/src/unix/print.js
+++ b/src/unix/print.js
@@ -3,14 +3,12 @@
 const fs = require("fs");
 const execAsync = require("../execAsync");
 
-const escapeWhitespaces = path => path.replace(/(\s+)/g, "\\$1");
-
 const print = (pdf, options = {}) => {
   if (!pdf) throw "No PDF specified";
   if (typeof pdf !== "string") throw "Invalid PDF name";
   if (!fs.existsSync(pdf)) throw "No such file";
 
-  const args = [escapeWhitespaces(pdf)];
+  const args = [pdf];
 
   const { printer } = options;
 


### PR DESCRIPTION
fix for #67. 

I think we don't need to escape whitespaces after we replaced `child_process.exec()`  with `child_process.execFile()` 