### PR TITLE
Changed from printer.list() to printer.getPrinters() in examples

### DIFF
--- a/examples/express-server/package-lock.json
+++ b/examples/express-server/package-lock.json
@@ -259,9 +259,9 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pdf-to-printer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-1.1.1.tgz",
-      "integrity": "sha512-WL1VsKbSHSaqV66lwNvM8GVD+HzP+EsDQKG6PU60EEaBdYRYr8pHU0TBKvcnh+15Zb681S7fhxm73JX/kqj1ig=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-1.4.1.tgz",
+      "integrity": "sha512-8jd0cEuu8kaNsBM3/36x9YLUFHIGz1yCC5ChxaUXuAKPfrakjMFJFcIvocnV4LLWsTKLGKTBOAIwYTbivb1EWQ=="
     },
     "proxy-addr": {
       "version": "2.0.5",

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "express": "4.17.1",
     "node-fetch": "2.6.0",
-    "pdf-to-printer": "1.1.1"
+    "pdf-to-printer": "^1.4.1"
   }
 }

--- a/examples/express-server/src/list.js
+++ b/examples/express-server/src/list.js
@@ -1,4 +1,4 @@
-const printer = require('pdf-to-printer');
+const printer = require("pdf-to-printer");
 
 function list(request, response) {
   function onSuccess(data) {
@@ -6,10 +6,13 @@ function list(request, response) {
   }
 
   function onError(error) {
-    response.send({ status: 'error', error });
+    response.send({ status: "error", error });
   }
 
-  printer.getPrinters().then(onSuccess).catch(onError);
+  printer
+  .getPrinters()
+  .then(onSuccess)
+  .catch(onError);
 }
 
 module.exports = list;

--- a/examples/express-server/src/list.js
+++ b/examples/express-server/src/list.js
@@ -1,4 +1,4 @@
-const printer = require("pdf-to-printer");
+const printer = require('pdf-to-printer');
 
 function list(request, response) {
   function onSuccess(data) {
@@ -6,13 +6,10 @@ function list(request, response) {
   }
 
   function onError(error) {
-    response.send({ status: "error", error });
+    response.send({ status: 'error', error });
   }
 
-  printer
-    .list()
-    .then(onSuccess)
-    .catch(onError);
+  printer.getPrinters().then(onSuccess).catch(onError);
 }
 
 module.exports = list;

--- a/examples/express-server/src/list.js
+++ b/examples/express-server/src/list.js
@@ -10,9 +10,9 @@ function list(request, response) {
   }
 
   printer
-  .getPrinters()
-  .then(onSuccess)
-  .catch(onError);
+    .getPrinters()
+    .then(onSuccess)
+    .catch(onError);
 }
 
 module.exports = list;


### PR DESCRIPTION
For version 1.4.1, changed list() to getPrinters() in examples.