### PR TITLE
Fix regression with printer and win32 options

### DIFF
--- a/src/electron-util.js
+++ b/src/electron-util.js
@@ -9,6 +9,6 @@ const isUsingAsar =
   process.mainModule &&
   process.mainModule.filename.includes("app.asar");
 
-export const fixPathForAsarUnpack = (path) => {
+exports.fixPathForAsarUnpack = (path) => {
   return isUsingAsar ? path.replace("app.asar", "app.asar.unpacked") : path;
 };

--- a/src/win32/print.js
+++ b/src/win32/print.js
@@ -5,6 +5,12 @@ const fs = require("fs");
 const execAsync = require("../execAsync");
 const { fixPathForAsarUnpack } = require("../electron-util");
 
+const validDestinationArgs = [
+  "-print-to",
+  "-print-to-default",
+  "-print-dialog",
+];
+
 const print = (pdf, options = {}) => {
   if (!pdf) throw "No PDF specified";
   if (typeof pdf !== "string") throw "Invalid PDF name";
@@ -20,7 +26,20 @@ const print = (pdf, options = {}) => {
   if (win32) {
     if (!Array.isArray(win32)) throw "options.win32 should be an array";
     win32.map((win32Arg) => args.push(...win32Arg.split(" ")));
-  } else {
+  }
+
+  let validDestination = false;
+  args.some((a) => {
+    const fullMatch = validDestinationArgs.indexOf(a) > -1;
+    if (fullMatch) {
+      validDestination = true;
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  if (!validDestination) {
     if (printer) {
       args.push("-print-to", printer);
     } else {

--- a/src/win32/print.test.js
+++ b/src/win32/print.test.js
@@ -68,7 +68,7 @@ test("sends PDF file to the specific printer", () => {
   });
 });
 
-test("allows users to pass OS specific options", () => {
+test("allows users to pass OS specific options and a printer", () => {
   const filename = "assets/pdf-sample.pdf";
   const printer = "Zebra";
   const options = { printer, win32: ['-print-settings "1,2,fit"'] };
@@ -76,6 +76,53 @@ test("allows users to pass OS specific options", () => {
     expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
       "-print-settings",
       '"1,2,fit"',
+      "-print-to",
+      printer,
+      "-silent",
+      filename,
+    ]);
+  });
+});
+
+test("allows users to pass OS specific options without a printer", () => {
+  const filename = "assets/pdf-sample.pdf";
+  const options = { win32: ['-print-settings "1,3,fit"'] };
+  return print(filename, options).then(() => {
+    expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
+      "-print-settings",
+      '"1,3,fit"',
+      "-print-to-default",
+      "-silent",
+      filename,
+    ]);
+  });
+});
+
+test("does not set a printer when -print-dialog is set", () => {
+  const filename = "assets/pdf-sample.pdf";
+  const options = { win32: ["-print-dialog", '-print-settings "1,4,fit"'] };
+  return print(filename, options).then(() => {
+    expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
+      "-print-dialog",
+      "-print-settings",
+      '"1,4,fit"',
+      filename,
+    ]);
+  });
+});
+
+test("ignores the passed printer when -print-dialog is set", () => {
+  const filename = "assets/pdf-sample.pdf";
+  const printer = "Zebra";
+  const options = {
+    printer,
+    win32: ["-print-dialog", '-print-settings "1,4,fit"'],
+  };
+  return print(filename, options).then(() => {
+    expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
+      "-print-dialog",
+      "-print-settings",
+      '"1,4,fit"',
       filename,
     ]);
   });


### PR DESCRIPTION
They could have not been set together due to a recent change in https://github.com/artiebits/pdf-to-printer/pull/221,
this fixes it and adds tests.