### PR TITLE
Add argument splitting logic

### DIFF
--- a/src/split-args.js
+++ b/src/split-args.js
@@ -1,0 +1,17 @@
+module.exports = function splitArgs(inputString) {
+  return String(inputString)
+    .match(/\\?.|^$/g)
+    .reduce(
+      (p, c) => {
+        if (c === '"') {
+          p.quote ^= 1;
+        } else if (!p.quote && c === " ") {
+          p.a.push("");
+        } else {
+          p.a[p.a.length - 1] += c.replace(/\\(.)/, "$1");
+        }
+        return p;
+      },
+      { a: [""] }
+    ).a;
+};

--- a/src/unix/print.js
+++ b/src/unix/print.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require("fs");
+const splitArgs = require("../split-args");
 const execAsync = require("../execAsync");
 
 const print = (pdf, options = {}) => {
@@ -18,7 +19,10 @@ const print = (pdf, options = {}) => {
 
   if (unix) {
     if (!Array.isArray(unix)) throw "options.unix should be an array";
-    unix.map((unixArg) => args.push(...unixArg.split(" ")));
+    unix
+      .map(splitArgs)
+      .reduce((acc, arg) => acc.concat(arg), [])
+      .forEach((arg) => args.push(arg));
   }
 
   return execAsync("lp", args);

--- a/src/unix/print.test.js
+++ b/src/unix/print.test.js
@@ -54,6 +54,15 @@ test("sends PDF file to the specific printer", () => {
   });
 });
 
+test("sends PDF file to the specific printer with a space in its name", () => {
+  const filename = "assets/pdf-sample.pdf";
+  const printer = "Brother HL-L2340WD";
+  const options = { printer };
+  return print(filename, options).then(() => {
+    expect(execAsync).toHaveBeenCalledWith("lp", [filename, "-d", printer]);
+  });
+});
+
 test("allows users to pass OS specific options", () => {
   const filename = "assets/pdf-sample.pdf";
   const printer = "Zebra";

--- a/src/win32/print.js
+++ b/src/win32/print.js
@@ -2,6 +2,7 @@
 
 const path = require("path");
 const fs = require("fs");
+const splitArgs = require("../split-args");
 const execAsync = require("../execAsync");
 const { fixPathForAsarUnpack } = require("../electron-util");
 
@@ -19,7 +20,10 @@ const print = (pdf, options = {}) => {
 
   if (win32) {
     if (!Array.isArray(win32)) throw "options.win32 should be an array";
-    win32.map((win32Arg) => args.push(...win32Arg.split(" ")));
+    win32
+      .map(splitArgs)
+      .reduce((acc, arg) => acc.concat(arg), [])
+      .forEach((arg) => args.push(arg));
   } else {
     if (printer) {
       args.push("-print-to", printer);

--- a/src/win32/print.test.js
+++ b/src/win32/print.test.js
@@ -68,6 +68,20 @@ test("sends PDF file to the specific printer", () => {
   });
 });
 
+test("sends PDF file to the specific printer with a space in its name", () => {
+  const filename = "assets/pdf-sample.pdf";
+  const printer = "Adobe PDF";
+  const options = { printer };
+  return print(filename, options).then(() => {
+    expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
+      "-print-to",
+      printer,
+      "-silent",
+      filename,
+    ]);
+  });
+});
+
 test("allows users to pass OS specific options", () => {
   const filename = "assets/pdf-sample.pdf";
   const printer = "Zebra";
@@ -75,7 +89,7 @@ test("allows users to pass OS specific options", () => {
   return print(filename, options).then(() => {
     expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
       "-print-settings",
-      '"1,2,fit"',
+      "1,2,fit",
       filename,
     ]);
   });

--- a/src/win32/print.test.js
+++ b/src/win32/print.test.js
@@ -70,7 +70,7 @@ test("sends PDF file to the specific printer", () => {
 
 test("sends PDF file to the specific printer with a space in its name", () => {
   const filename = "assets/pdf-sample.pdf";
-  const printer = "Adobe PDF";
+  const printer = "Microsoft Print to PDF";
   const options = { printer };
   return print(filename, options).then(() => {
     expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [


### PR DESCRIPTION
This solves the issue with spaces in printer names, and removes the expectation of invocation with quotes which are dealt with by Node's child_process.