### PR TITLE
Fixed README.md codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ ptp
   .catch(console.error);
 ```
 
-### `.getDefaultPrinter() => Promise<PrinterObject>`
+### `.getDefaultPrinter() => Promise<PrinterObject> | false`
 
 **Returns**
 
-`Promise<PrinterObject>`: Default printer.
+`Promise<PrinterObject> | false`: Default printer or `false` if there is no default printer.
 
 **Examples**
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Print a PDF file to the default printer:
 ```javascript
 import ptp from "pdf-to-printer";
 
-ptp.print("assets/pdf-sample.pdf").then(console.log).catch(console.error);
+ptp
+  .print("assets/pdf-sample.pdf")
+  .then(console.log)
+  .catch(console.error);
 ```
 
 ## API
@@ -55,7 +58,10 @@ ptp.print("assets/pdf-sample.pdf").then(console.log).catch(console.error);
 To print a PDF file to the default printer:
 
 ```javascript
-ptp.print("assets/pdf-sample.pdf").then(console.log).catch(console.error);
+ptp
+  .print("assets/pdf-sample.pdf")
+  .then(console.log)
+  .catch(console.error);
 ```
 
 To print to a specific printer, add the device id of the printer to options:
@@ -95,7 +101,10 @@ ptp
 **Examples**
 
 ```javascript
-ptp.getPrinters().then(console.log).catch(console.error);
+ptp
+  .getPrinters()
+  .then(console.log)
+  .catch(console.error);
 ```
 
 ### `.getDefaultPrinter() => Promise<PrinterObject>`
@@ -107,7 +116,10 @@ ptp.getPrinters().then(console.log).catch(console.error);
 **Examples**
 
 ```javascript
-ptp.getDefaultPrinter().then(console.log).catch(console.error);
+ptp
+  .getDefaultPrinter()
+  .then(console.log)
+  .catch(console.error);
 ```
 
 ## Objects


### PR DESCRIPTION
Fixed `README.md` codeblocks that got reformatted by my IDE when I initially updated it to reflect the changes added by me. 

@artiebits you might want to test the changes added by me too before making it an official release(As I mentioned [here](https://github.com/artiebits/pdf-to-printer/issues/220#issuecomment-776590498), if you want to easily test this and you have a machine running linux available, you can install `cups-pdf` to set up a virtual printer). Also, this should be considered a major update as it can break projects that at the moment use version `<= 1.7.0`. The owners of said projects must migrate their code where necessary.

**Edit:** Also, publish another beta version to npm so I can give it to some people to test it. I already tested it while working on it, but let's be safe rather than sorry.