### PR TITLE
fix printer detection when there is somewhere else the string "printer"

### DIFF
--- a/src/unix/get-printers.js
+++ b/src/unix/get-printers.js
@@ -5,7 +5,7 @@ const execAsync = require("../execAsync");
 const getPrinters = () => {
   const parseResult = (output) => {
     return output
-      .split("printer")
+      .split(/^printer/m)
       .slice(1)
       .map((e) => {
         e = e.trim();


### PR DESCRIPTION
example
```
printer HP_Officejet_Pro_8620_605699_ disabled since Do 25 Mär 2021 12:01:53 -
	No destination host name supplied by cups-browsed for printer "HP_Officejet_Pro_8620_605699_", is cups-browsed running?
	Form mounted:
	Content types: any
	Printer types: unknown
```

This will break because of the "printer" in "... cups-browsed for **printer** "HP_Offi ..."

The solution is to only split on "printer" when it is in the beginning of the text line.