### PR TITLE
fix lint script on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "prettier --write 'src/**/*.{js,ts,json,md}' 'webpack.production.config.js' 'examples'",
+    "lint": "prettier --write \"src/**/*.{js,ts,json,md}\" \"webpack.production.config.js\" \"examples\"",
     "build": "webpack --config webpack.production.config.js",
     "prepublishOnly": "npm run lint && npm run test && npm run build"
   },


### PR DESCRIPTION
fix `npm run lint` on windows

Based on the following comment, https://github.com/prettier/prettier/issues/4804#issuecomment-402476898, prettier needs double quotes to work under windows