### PR TITLE
Improve split by regex to only find real printers instead of everything that starts with printer

### DIFF
--- a/src/unix/get-printers.js
+++ b/src/unix/get-printers.js
@@ -5,13 +5,13 @@ const execAsync = require("../utils/exec-async");
 async function getPrinters() {
   function parseResult(stdout) {
     return stdout
-      .split("printer")
-      .slice(1)
-      .map((e) => {
-        e = e.trim();
+      .split(/^printer(.)/gm)
+      .filter((line) => line.trim() !== "")
+      .map((line) => {
+        const trimmed = line.trim();
         return {
-          deviceId: e.substr(0, e.indexOf(" ")),
-          name: e
+          deviceId: trimmed.substr(0, trimmed.indexOf(" ")),
+          name: trimmed
             .split("\n")
             .slice(1)
             .find((line) => line.indexOf("Description") !== -1)

--- a/src/unix/get-printers.test.js
+++ b/src/unix/get-printers.test.js
@@ -4,6 +4,7 @@ import execAsync from "../utils/exec-async";
 jest.mock("../utils/exec-async");
 
 const stdout = `printer Virtual_PDF_Printer is idle.  enabled since Tue 30 Mar 2021 11:54:05 PM EEST
+The printer configuration is incorrect or the printer no longer exists
 Form mounted:
 Content types: any
 Printer types: unknown
@@ -15,6 +16,7 @@ Interface: /etc/cups/ppd/Virtual_PDF_Printer.ppd
 On fault: no alert
 After fault: continue
 printer Zebra is idle.  enabled since Tue 09 Feb 2021 12:32:35 AM EET
+The printer configuration is incorrect or the printer no longer exists
 Form mounted:
 Content types: any
 Printer types: unknown


### PR DESCRIPTION
We have came across a problem which seems to be an edge case but can still occure for many on OSX (or Unix systems).
If you had some troubles adding/removing printes in the past `lpstat -lp` can return a text which has a printer error e.g `The printer configuration is incorrect or the printer no longer exists` and the current way of dealing with the text will pick this up as a printer since the word **printer** is present. 

Solution:

Improved the codebase by using a regex which will only pick up printers if the line begins with the word printer.
This isn't 100% bulletproof but it seems to solve the edge case according to the unit tests.

