### PR TITLE
fix(build): proper refer to built ts declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/artiebits/pdf-to-printer.git"
   },
   "main": "dist/bundle.js",
-  "types": "dist/**/*.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #292 