### PR TITLE
Feature: add `copies` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A function to print a PDF document.
    - `paperSize` (`string`, Optional): Specifies the paper size. Supported names `A2`, `A3`, `A4`, `A5`, `A6`, `letter`, `legal`, `tabloid`, `statement`.
    - `silent` (`boolean`, Optional): Silences SumatraPDF's error messages.
    - `printDialog` (`boolean`, Optional): displays the Print dialog for all the files indicated on this command line.
+   - `copies`(`number`, Optional): Specifies how many copies will be printed.
 
 **Returns**
 

--- a/src/print/print.spec.ts
+++ b/src/print/print.spec.ts
@@ -313,6 +313,23 @@ describe("bin", () => {
   });
 });
 
+describe("copies", () => {
+  it("file should be printed a specified amount of times", async () => {
+    const filename = "assets/sample.pdf";
+    const options = { copies: 3 };
+
+    await print(filename, options);
+
+    expect(execAsync).toHaveBeenCalledWith("mocked_path_SumatraPDF.exe", [
+      "-print-to-default",
+      "-silent",
+      "-print-settings",
+      "3x",
+      filename,
+    ]);
+  });
+});
+
 it("does not set a printer when printDialog is set to true", async () => {
   const filename = "assets/sample.pdf";
   const options = { printer: "Zebra", printDialog: true };

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -17,6 +17,7 @@ export interface PrintOptions {
   silent?: boolean;
   printDialog?: boolean;
   sumatraPdfPath?: string;
+  copies?: number;
 }
 
 const validSubsets = ["odd", "even"];
@@ -89,6 +90,7 @@ function getPrintSettings(options: PrintOptions): string[] {
     side,
     bin,
     paperSize,
+    copies,
   } = options;
 
   const printSettings = [];
@@ -149,6 +151,10 @@ function getPrintSettings(options: PrintOptions): string[] {
         ", "
       )}`;
     }
+  }
+
+  if (copies) {
+    printSettings.push(`${copies}x`);
   }
 
   return printSettings;


### PR DESCRIPTION
This PR fixes https://github.com/artiebits/pdf-to-printer/issues/288

- Added the `copies` parameter to the `options` object
- Added test coverage
- Added param description to README
- Tested on a Windows machine with printer, worked fine.

Usage: 
```ts
const options = {
  copies: 4
};
print(file, options).then(console.log);
```