### PR TITLE
remove validPaperSizes

### DIFF
--- a/src/print/print.spec.ts
+++ b/src/print/print.spec.ts
@@ -125,17 +125,6 @@ describe("paper size", () => {
       ]);
     });
   });
-
-  it("throws when incorrect paper size provided", () => {
-    const filename = "assets/sample.pdf";
-    const options = {
-      paperSize: "foo",
-    };
-
-    return expect(print(filename, options)).rejects.toBe(
-      "Invalid paper size provided. Valid names: A2, A3, A4, A5, A6, letter, legal, tabloid, statement"
-    );
-  });
 });
 
 describe("orientation", () => {

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -24,17 +24,6 @@ const validSubsets = ["odd", "even"];
 const validOrientations = ["portrait", "landscape"];
 const validScales = ["noscale", "shrink", "fit"];
 const validSides = ["duplex", "duplexshort", "duplexlong", "simplex"];
-const validPaperSizes = [
-  "A2",
-  "A3",
-  "A4",
-  "A5",
-  "A6",
-  "letter",
-  "legal",
-  "tabloid",
-  "statement",
-];
 
 export default async function print(
   pdf: string,
@@ -144,13 +133,7 @@ function getPrintSettings(options: PrintOptions): string[] {
   }
 
   if (paperSize) {
-    if (validPaperSizes.includes(paperSize)) {
-      printSettings.push(`paper=${paperSize}`);
-    } else {
-      throw `Invalid paper size provided. Valid names: ${validPaperSizes.join(
-        ", "
-      )}`;
-    }
+    printSettings.push(`paper=${paperSize}`);
   }
 
   if (copies) {


### PR DESCRIPTION
Every printer can have different valid paper sizes, so I don't think we can hardcode them. 

Implementing a getter to retrieve valid papersizes for each platform by printername is out of the scope of this project.