### PR TITLE
feat: remove paperSize validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ print("assets/Labeli.pdf", {
 })
 ```
 
-The value in this example of `4.00x3.00(102mm x 76mm)` should exist in your printing preference. settings.
+The value in this example of `4.00x3.00(102mm x 76mm)` should exist in your printing preference settings.
 
 ## Sponsor this project
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A function to print a PDF document.
    - `monochrome` (`boolean`, Optional): Prints the document in black and white. Default is `false`.
    - `side` (`string`, Optional): Supported names `duplex`, `duplexshort`, `duplexlong` and `simplex`.
    - `bin` (`string`, Optional): Select tray to print to. Number or name.
-   - `paperSize` (`string`, Optional): Specifies the paper size. Supported names `A2`, `A3`, `A4`, `A5`, `A6`, `letter`, `legal`, `tabloid`, `statement`.
+   - `paperSize` (`string`, Optional): Specifies the paper size. On windows you can find this as a dropdown selection in your printer preference. Refer to Printer Size note below.
    - `silent` (`boolean`, Optional): Silences SumatraPDF's error messages.
    - `printDialog` (`boolean`, Optional): displays the Print dialog for all the files indicated on this command line.
    - `copies`(`number`, Optional): Specifies how many copies will be printed.
@@ -145,6 +145,17 @@ import { getDefaultPrinter } from "pdf-to-printer";
 
 getDefaultPrinter().then(console.log);
 ```
+
+**Printer Size Notes**
+If you need 4"x3" paper size and assuming it is selectable from your printer preference settings, you can set the following:
+
+```
+print("assets/Labeli.pdf", {
+        paperSize: "4.00\"x3.00\"(102mm x 76mm)"
+})
+```
+
+The value in this example of `4.00x3.00(102mm x 76mm)` should exist in your printing preference. settings.
 
 ## Sponsor this project
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ import { getDefaultPrinter } from "pdf-to-printer";
 getDefaultPrinter().then(console.log);
 ```
 
-**Printer Size Notes**
+### Printer Size Notes
+
 If you need 4"x3" paper size and assuming it is selectable from your printer preference settings, you can set the following:
 
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ getDefaultPrinter().then(console.log);
 
 ### Printer Size Notes
 
-If you need 4"x3" paper size and assuming it is selectable from your printer preference settings, you can set the following:
+For example, If you need 4"x3" paper size and assuming it is selectable from your printer preference settings, you can set the following:
 
 ```
 print("assets/Labeli.pdf", {

--- a/src/print/print.spec.ts
+++ b/src/print/print.spec.ts
@@ -125,17 +125,6 @@ describe("paper size", () => {
       ]);
     });
   });
-
-  it("throws when incorrect paper size provided", () => {
-    const filename = "assets/sample.pdf";
-    const options = {
-      paperSize: "foo",
-    };
-
-    return expect(print(filename, options)).rejects.toBe(
-      "Invalid paper size provided. Valid names: A2, A3, A4, A5, A6, letter, legal, tabloid, statement"
-    );
-  });
 });
 
 describe("orientation", () => {

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -143,14 +143,11 @@ function getPrintSettings(options: PrintOptions): string[] {
     printSettings.push(`bin=${bin}`);
   }
 
+  // paper size is represented by the drop down from your printer preference.
+  // For example if you need 4"x3" labels, you would set papersize to
+  // { paperSize: "4.00\"x3.00\"(102mm x 76mm)" }
   if (paperSize) {
-    if (validPaperSizes.includes(paperSize)) {
-      printSettings.push(`paper=${paperSize}`);
-    } else {
-      throw `Invalid paper size provided. Valid names: ${validPaperSizes.join(
-        ", "
-      )}`;
-    }
+    printSettings.push(`paper=${paperSize}`);
   }
 
   if (copies) {

--- a/src/print/print.ts
+++ b/src/print/print.ts
@@ -24,17 +24,6 @@ const validSubsets = ["odd", "even"];
 const validOrientations = ["portrait", "landscape"];
 const validScales = ["noscale", "shrink", "fit"];
 const validSides = ["duplex", "duplexshort", "duplexlong", "simplex"];
-const validPaperSizes = [
-  "A2",
-  "A3",
-  "A4",
-  "A5",
-  "A6",
-  "letter",
-  "legal",
-  "tabloid",
-  "statement",
-];
 
 export default async function print(
   pdf: string,


### PR DESCRIPTION
This PR is to allow folks to select their own papersize. I was able to test this against my 4"x3" labels on my thermal printer. The papersize is dictated by the dropdown someone would select 

![image](https://user-images.githubusercontent.com/9097501/166802755-07b670fd-5a43-4c64-a278-ce01a1b05c3b.png)

So in my case for my issue ticket - https://github.com/artiebits/pdf-to-printer/issues/369

what fixed my issue is the following printerSetting:

        print("assets/Labeli.pdf", {
            paperSize: "4.00\"x3.00\"(102mm x 76mm)",
            orientation: "landscape"
        })