### PR TITLE
fix: force utf-8 output encoding for non-ascii printer names

### DIFF
--- a/src/get-default-printer/get-default-printer.ts
+++ b/src/get-default-printer/get-default-printer.ts
@@ -27,7 +27,7 @@ async function getDefaultPrinter(): Promise<Printer | null> {
 
     const { stdout } = await execFileAsync("Powershell.exe", [
       "-Command",
-      `Get-CimInstance Win32_Printer -Property DeviceID,Name,PrinterPaperNames -Filter Default=true`,
+      `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-CimInstance Win32_Printer -Property DeviceID,Name,PrinterPaperNames -Filter Default=true`,
     ]);
 
     const printer = stdout.trim();

--- a/src/get-printers/get-printers.ts
+++ b/src/get-printers/get-printers.ts
@@ -42,7 +42,7 @@ async function getPrinters(): Promise<Printer[]> {
     throwIfUnsupportedOperatingSystem();
     const { stdout } = await execFileAsync("Powershell.exe", [
       "-Command",
-      `Get-CimInstance Win32_Printer -Property DeviceID,Name,PrinterPaperNames`,
+      `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); Get-CimInstance Win32_Printer -Property DeviceID,Name,PrinterPaperNames`,
     ]);
     return stdoutHandler(stdout);
   } catch (error) {


### PR DESCRIPTION
Fixes #551

  **Before / after (real repro on Windows, printer named `PDF24-Принтер`)**

  Before (current `main`):
  Status                      :
  Name                        : PDF24-�ਭ��
  DeviceID                    : PDF24-�ਭ��

  After (with the fix):
  Status                      :
  Name                        : PDF24-Принтер
  DeviceID                    : PDF24-Принтер
